### PR TITLE
fix: nil pointer exception on profile download

### DIFF
--- a/lpa/download.go
+++ b/lpa/download.go
@@ -37,7 +37,7 @@ func (c *Client) DownloadProfile(ctx context.Context, ac *ActivationCode, handle
 	handler.Progress(DownloadProgressAuthenticateClient)
 	clientResponse, metadata, ccRequired, err := c.authenticateClient(ac)
 	if err != nil {
-		if clientResponse.Header.ExecutionStatus.ExecutedSuccess() {
+		if clientResponse.Header != nil && clientResponse.Header.ExecutionStatus != nil && clientResponse.Header.ExecutionStatus.ExecutedSuccess() {
 			return nil, c.raiseError(ac, clientResponse.TransactionID, err, sgp22.CancelSessionReasonEndUserRejection)
 		}
 		return nil, err


### PR DESCRIPTION
When downloading a profile, if the header or execution status might not exist if the SM-DP+ returned an error, causing a nil pointer exception instead of a standard error.