### PR TITLE
fix: handle nil response headers and missing optional TLV fields to p…

### DIFF
--- a/v2/es11.go
+++ b/v2/es11.go
@@ -19,7 +19,7 @@ type ES11AuthenticateClientResponse struct {
 }
 
 func (r *ES11AuthenticateClientResponse) FunctionExecutionStatus() *ExecutionStatus {
-	return r.Header.ExecutionStatus
+	return HeaderExecutionStatus(r.Header)
 }
 
 type EventEntry struct {

--- a/v2/es9p.go
+++ b/v2/es9p.go
@@ -1,6 +1,8 @@
 package sgp22
 
 import (
+	"errors"
+	"fmt"
 	"net/url"
 
 	"github.com/damonto/euicc-go/bertlv"
@@ -32,7 +34,7 @@ type ES9InitiateAuthenticationResponse struct {
 }
 
 func (r *ES9InitiateAuthenticationResponse) FunctionExecutionStatus() *ExecutionStatus {
-	return r.Header.ExecutionStatus
+	return HeaderExecutionStatus(r.Header)
 }
 
 func (r *ES9InitiateAuthenticationResponse) CardRequest() *AuthenticateServerRequest {
@@ -81,7 +83,7 @@ type ES9BoundProfilePackageResponse struct {
 }
 
 func (r *ES9BoundProfilePackageResponse) FunctionExecutionStatus() *ExecutionStatus {
-	return r.Header.ExecutionStatus
+	return HeaderExecutionStatus(r.Header)
 }
 
 func (r *ES9BoundProfilePackageResponse) CardRequest() *LoadBoundProfilePackageRequest {
@@ -114,7 +116,50 @@ func (r *ES9AuthenticateClientRequest) UnmarshalBERTLV(tlv *bertlv.TLV) error {
 }
 
 func (r *ES9AuthenticateClientRequest) Valid() error {
+	if r.Response == nil {
+		return errors.New("eUICC did not return AuthenticateServer response")
+	}
+	// AuthenticateServerResponse ::= [56] CHOICE {
+	//   authenticateResponseOk    [0],
+	//   authenticateResponseError [1] { transactionId, authenticateErrorCode }
+	// }
+	//The error branch indicates that the eUICC rejected the server authentication of SM-DP+; at this time, the error response should not be forwarded to SM-DP+, but should crash directly.
+	if errBranch := r.Response.First(bertlv.ContextSpecific.Constructed(1)); errBranch != nil {
+		code := -1
+		if codeTLV := errBranch.First(bertlv.Universal.Primitive(2)); codeTLV != nil {
+			code = 0
+			for _, b := range codeTLV.Value {
+				code = code<<8 | int(b)
+			}
+		}
+		return fmt.Errorf("eUICC rejected SM-DP+ server authentication (authenticateResponseError, errorCode=%d: %s)", code, authenticateErrorCodeString(code))
+	}
 	return nil
+}
+
+// authenticateErrorCodeString maps an ES10b.AuthenticateServer error code to
+// its SGP.22 name. See AuthenticateErrorCode in SGP.22 §5.7.13.
+func authenticateErrorCodeString(code int) string {
+	switch code {
+	case 1:
+		return "invalidCertificate"
+	case 2:
+		return "invalidSignature"
+	case 3:
+		return "unsupportedCurve"
+	case 4:
+		return "noSessionContext"
+	case 5:
+		return "invalidOID"
+	case 6:
+		return "euiccChallengeMismatch"
+	case 7:
+		return "ciPKUnknown"
+	case 127:
+		return "undefinedError"
+	default:
+		return "unknown"
+	}
 }
 
 type ES9AuthenticateClientResponse struct {
@@ -127,7 +172,7 @@ type ES9AuthenticateClientResponse struct {
 }
 
 func (r *ES9AuthenticateClientResponse) FunctionExecutionStatus() *ExecutionStatus {
-	return r.Header.ExecutionStatus
+	return HeaderExecutionStatus(r.Header)
 }
 
 func (r *ES9AuthenticateClientResponse) CardRequest() *PrepareDownloadRequest {
@@ -207,7 +252,7 @@ type ES9CancelSessionResponse struct {
 }
 
 func (r *ES9CancelSessionResponse) FunctionExecutionStatus() *ExecutionStatus {
-	return r.Header.ExecutionStatus
+	return HeaderExecutionStatus(r.Header)
 }
 
 // endregion

--- a/v2/profile.go
+++ b/v2/profile.go
@@ -21,14 +21,24 @@ type ProfileInfo struct {
 	NotificationConfigurationInfo NotificationConfigurationInfo
 }
 
+// firstValue returns the value of the first child carrying tag, or nil when the
+// (optional) tag is absent. Many real-world profiles omit optional fields such
+// as serviceProviderName; callers must not dereference a nil *TLV.
+func firstValue(tlv *bertlv.TLV, tag bertlv.Tag) []byte {
+	if child := tlv.First(tag); child != nil {
+		return child.Value
+	}
+	return nil
+}
+
 func (p *ProfileInfo) UnmarshalBERTLV(tlv *bertlv.TLV) error {
 	if !tlv.Tag.If(bertlv.Private, bertlv.Constructed, 3) && !tlv.Tag.If(bertlv.ContextSpecific, bertlv.Constructed, 37) {
 		return ErrUnexpectedTag
 	}
 	*p = ProfileInfo{
-		ICCID:               tlv.First(bertlv.Application.Primitive(26)).Value,
-		ServiceProviderName: string(tlv.First(bertlv.ContextSpecific.Primitive(17)).Value),
-		ProfileName:         string(tlv.First(bertlv.ContextSpecific.Primitive(18)).Value),
+		ICCID:               firstValue(tlv, bertlv.Application.Primitive(26)),
+		ServiceProviderName: string(firstValue(tlv, bertlv.ContextSpecific.Primitive(17))),
+		ProfileName:         string(firstValue(tlv, bertlv.ContextSpecific.Primitive(18))),
 		ProfileClass:        ProfileClassProvisioning,
 	}
 	if profileClass := tlv.First(bertlv.ContextSpecific.Primitive(21)); profileClass != nil {
@@ -44,8 +54,10 @@ func (p *ProfileInfo) UnmarshalBERTLV(tlv *bertlv.TLV) error {
 		p.Icon = icon.Value
 	}
 	if tlv.Tag.If(bertlv.Private, bertlv.Constructed, 3) {
-		if err := tlv.First(bertlv.ContextSpecific.Primitive(112)).UnmarshalValue(primitive.UnmarshalInt(&p.ProfileState)); err != nil {
-			return err
+		if state := tlv.First(bertlv.ContextSpecific.Primitive(112)); state != nil {
+			if err := state.UnmarshalValue(primitive.UnmarshalInt(&p.ProfileState)); err != nil {
+				return err
+			}
 		}
 	}
 	if notification := tlv.First(bertlv.ContextSpecific.Constructed(22)); notification != nil {

--- a/v2/rsp_header.go
+++ b/v2/rsp_header.go
@@ -15,6 +15,24 @@ func (h Header) Error() error {
 	return h.ExecutionStatus.StatusCodeData
 }
 
+// HeaderExecutionStatus returns the execution status of an ES9+ response,
+// synthesising a failed status when the header is missing. An SM-DP+ that
+// replies with an empty or invalid body leaves Header (and thus
+// ExecutionStatus) nil; callers dereference the returned status on the failure
+// path, so returning nil here would panic. Always return a non-nil status with
+// a non-nil StatusCodeData instead.
+func HeaderExecutionStatus(h *Header) *ExecutionStatus {
+	if h == nil || h.ExecutionStatus == nil {
+		return &ExecutionStatus{
+			Status: "Failed",
+			StatusCodeData: &StatusCodeData{
+				Message: "SM-DP+ returned an empty or invalid response (missing functionExecutionStatus)",
+			},
+		}
+	}
+	return h.ExecutionStatus
+}
+
 type ExecutionStatus struct {
 	Status         string          `json:"status,omitempty"`
 	StatusCodeData *StatusCodeData `json:"statusCodeData,omitempty"`


### PR DESCRIPTION
- 增加对 ProfileInfo 中可选 TLV 字段（如 运营商 ）的空值保护，防止解析时发生崩溃
- 增加对 SM-DP+ 返回空响应体或无效 Header 时的防御，合成失败的 ExecutionStatus
- 增加对 eUICC 拒绝 SM-DP+ 服务端认证（authenticateResponseError）的错误分支解析与映射